### PR TITLE
Improve WorldMap visualization and transparency

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -79,7 +79,7 @@ function App () {
           }}
         >
           <strong>Work in Progress:</strong> This dashboard is currently under
-          active development. Evaluation results are not yet final. Note that the visualised results currently stem from sampling 10 instances per combination of model, task, and language. More extensive evaluation runs will be released later this year.
+          active development. Evaluation results are not yet final. Note that the visualised results currently stem from sampling 10 instances per combination of model, task, and language. Only the top 100 languages by speaker count are included. More extensive evaluation runs will be released later this year.
         </div>
         <div
           style={{

--- a/frontend/src/components/WorldMap.js
+++ b/frontend/src/components/WorldMap.js
@@ -49,7 +49,7 @@ const WorldMap = ({ data, width = 750, height = 500 }) => {
       return acc
     }, {})
     const plot = Plot.plot({
-      subtitle: 'Language Proficiency Score by Country',
+      subtitle: 'Language Proficiency Score by Country (Coverage: ~65/194 benchmark languages)',
       width: width,
       height: height,
       projection: 'equal-earth',
@@ -61,11 +61,12 @@ const WorldMap = ({ data, width = 750, height = 500 }) => {
         })
       ],
       color: {
-        scheme: 'Greens',
-        unknown: 'gray',
+        scheme: 'RdYlGn',
+        unknown: '#d0d0d0',
         label: 'Score',
         legend: true,
-        domain: [0, 1]
+        domain: [0, 1],
+        pivot: 0.5
       },
       style: {
         fontFamily: 'monospace'


### PR DESCRIPTION
- Change color scheme from Greens to RdYlGn for better investment visibility
- Add pivot point (0.5) to center diverging color scale
- Update map subtitle to indicate current coverage (~65/194 languages)
- Improve country exclusion styling with darker grey (#d0d0d0)
- Update disclaimer to clarify top 100 languages limitation
- Enhance visual indication of areas needing investment (red) vs well-supported (green)