### PR TITLE
Grey out low-population countries on WorldMap

### DIFF
--- a/evals/countries.py
+++ b/evals/countries.py
@@ -30,10 +30,15 @@ def make_country_table(language_table):
             )
     for country, languages in countries.items():
         speaker_pop = sum(entry["population"] for entry in languages)
-        score = (
-            sum(entry["score"] * entry["population"] for entry in languages)
-            / speaker_pop
-        )
+        
+        if speaker_pop < 1000:  # 🎯 Grey out low-population countries
+            score = None  # This will make them appear grey on the map
+        else:
+            score = (
+                sum(entry["score"] * entry["population"] for entry in languages)
+                / speaker_pop
+            )
+        
         countries[country] = {
             "score": score,
             "languages": languages,


### PR DESCRIPTION
- Set score to None for countries with <1000 total language speakers
- Countries like Antarctica now appear grey instead of being removed
- Maintains visual presence while indicating insufficient data
- Provides cleaner map focus on countries with meaningful language communities